### PR TITLE
build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: generic
+sudo: required
+dist: trusty
+
+matrix:
+  fast_finish: true
+  include:
+    - env: COQ_VERSION="8.6"   COQ_PACKAGE="coq-8.6" PPA="ppa:jgross-h/many-coq-versions"
+    - env: COQ_VERSION="trunk" COQ_PACKAGE="coq"     PPA="ppa:jgross-h/coq-trunk-daily"
+    - env: COQ_VERSION="v8.7"  COQ_PACKAGE="coq"     PPA="ppa:jgross-h/coq-8.7-daily"
+    - env: COQ_VERSION="v8.6"  COQ_PACKAGE="coq"     PPA="ppa:jgross-h/coq-8.6-daily"
+    - env: COQ_VERSION="v8.5"  COQ_PACKAGE="coq"     PPA="ppa:jgross-h/coq-8.5-daily"
+  allow_failures:
+    - env: COQ_VERSION="trunk" COQ_PACKAGE="coq"     PPA="ppa:jgross-h/coq-trunk-daily"
+    - env: COQ_VERSION="v8.7"  COQ_PACKAGE="coq"     PPA="ppa:jgross-h/coq-8.7-daily"
+    - env: COQ_VERSION="v8.6"  COQ_PACKAGE="coq"     PPA="ppa:jgross-h/coq-8.6-daily"
+    - env: COQ_VERSION="v8.5"  COQ_PACKAGE="coq"     PPA="ppa:jgross-h/coq-8.5-daily"
+
+before_install:
+  - if [ ! -z "$PPA" ]; then sudo add-apt-repository "$PPA" -y; fi
+  - sudo apt-get update -q
+  - sudo apt-get install $COQ_PACKAGE -y
+
+script: make $TARGETS TIMED=1 -j2


### PR DESCRIPTION
All versions except for 8.6-stable are listed as "allowed failures" and will not trigger nastygrams.