### PR TITLE
Adapt to fixing dropped implicit arguments in Context.

### DIFF
--- a/src/Loops.v
+++ b/src/Loops.v
@@ -50,7 +50,7 @@ Module Import core.
                end.
     Qed.
 
-    Context (body_cps2 : A -> forall {R}, (A -> R) -> (B -> R) -> R).
+    Context (body_cps2 : A -> forall R, (A -> R) -> (B -> R) -> R).
     Fixpoint loop_cps2 (fuel : nat) (s : A) {R} (timeout:A->R) (ret:B->R) {struct fuel} : R :=
       body_cps2 s R
                 (fun a =>
@@ -60,7 +60,7 @@ Module Import core.
                    end)
                 (fun b => ret b).
 
-    Context (body_cps2_ok : forall s {R} continue break,
+    Context (body_cps2_ok : forall s R continue break,
                 body_cps2 s R continue break =
                 match body s with
                 | inl a => continue a


### PR DESCRIPTION
Hi, implicit arguments in `Context` were discarded. Coq PR [#11390](https://github.com/coq/coq/pull/11390) preserves them. The present PR adapts cross-crypto to the new semantics.

I tried first to preserve the implicit argument in `body_cps2` but it happens not to be inferable later, so, I finally dropped the implicit argument.

The PR is backwards-compatible and can be merged as soon as now.