### PR TITLE
Adapt w.r.t. coq/coq#17564.

### DIFF
--- a/src/Loops.v
+++ b/src/Loops.v
@@ -271,7 +271,7 @@ Module Import core.
             try (rewrite loop_fuel_0 in Hs; congruence); [].
           pose proof (iterations_required_step _ _ s' _ Hs' Hstep) as HA.
           rewrite HA.
-          destruct (proj1 (iterations_required_correct _ _) _ HA) as [? [? [? HE']]].
+          edestruct (proj1 (iterations_required_correct _ _) _ HA) as [? [? [? HE']]].
           pose proof (HE' ltac:(constructor)) as HE; clear HE'.
           split; [|lia].
           rewrite loop_fuel_S_first, Hstep in Hs.


### PR DESCRIPTION
This is backwards compatible.

The current master branch exploits a bug in the intropattern evaluation, where a split pattern is successfully applied to a higher-order hypothesis even though the dependent argument cannot be solved.